### PR TITLE
Feat/US01

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,30 @@
+name: Publish Docker Image
+
+on:
+  pull_request:
+    branches:
+      - develop
+    types:
+      - closed
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout do código
+        uses: actions/checkout@v4
+
+      - name: Login no DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build e Push da imagem
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/measuresoftgram-action:latest

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,9 @@ action-metrics:
 
 action-linter:
 	docker exec -it msgram-action act -j ESLint -W .github/workflows/linter.yml
+
+action-docker-publish:
+	docker exec -it msgram-action act pull_request \
+		-j build-and-push \
+		-W .github/workflows/docker-publish.yml \
+		--secret-file /workspace/env-vars/.action.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   service:
     container_name: msgram-service
-    image: joaoseisei1/msgram-service:1.0
+    image: 2026measuresoftgram/measuresoftgram-service:latest
     command: [ "./start_service.sh" ]
     ports:
       - "8080:8080"

--- a/env-vars-example/.action.env
+++ b/env-vars-example/.action.env
@@ -2,3 +2,7 @@ GITHUB_TOKEN=TOKEN
 SONAR_TOKEN=fga-eps-mds_MeasureSoftGram-Action
 MSGRAM_TOKEN=008eb933b3f464e8f7c28dd3e5b01516398a0f3b
 MSGRAM_SERVICE_HOST=http://localhost:8080
+
+# Caso queira testar o envio para o dockerhub:
+DOCKERHUB_USERNAME=EXAMPLE
+DOCKERHUB_TOKEN=EXAMPLE


### PR DESCRIPTION
# Configurar pipeline de publicação no DockerHub

## Descrição

Este Pull Request adiciona a pipeline de CI/CD responsável por realizar o build e a publicação automática da imagem Docker no DockerHub sempre que um PR for aberto ou atualizado com destino à branch `develop`, garantindo que a tag `latest` reflita sempre o build mais recente.

[[Configurar Dockerhub](https://github.com/fga-eps-mds/2026.1-MeasureSoftGram-Action/issues/8)](https://github.com/fga-eps-mds/2026.1-MeasureSoftGram-Action/issues/8)

## Porque este Pull Request é necessário?

Sem uma pipeline automatizada, as imagens Docker dos microsserviços precisavam ser geradas e publicadas manualmente, o que tornava o ambiente de desenvolvimento local dependente de versões desatualizadas. Com essa configuração, qualquer PR na `develop` dispara automaticamente o build e a publicação da imagem com a tag `latest` no DockerHub, garantindo que todos os desenvolvedores sempre utilizem a versão mais recente do serviço.

## Critérios de aceitação

1. [x] A pipeline é disparada automaticamente a cada PR aberto ou atualizado com destino à branch `develop`?
2. [x] A imagem Docker é gerada e publicada no DockerHub com a tag `latest` após um build bem-sucedido?
3. [x] A autenticação com o DockerHub é feita de forma segura via secrets do repositório?
4. [x] Builds com falha não sobrescrevem a tag `latest` no registry?
5. [x] O `docker-compose` local referencia a imagem mais recente do `msgram-service`?

Closes #8