### PR TITLE
fix: corrige porta do banco de dados

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
   db:
     container_name: msgram-postgres
     image: postgres:18-alpine
-    ports:
-      - "5432:5432"
     volumes:
       - service_postgres_data:/var/lib/postgresql
     env_file:


### PR DESCRIPTION
### Descrição

Este Pull Request corrige a configuração do docker-compose.yml da action, onde o banco de dados PostgreSQL estava com a porta 5432 exposta em todas as interfaces de rede do host (0.0.0.0). Na prática, o banco deve ser acessível apenas internamente pela rede Docker, sem bind no host.

---

### Por que este Pull Request é necessário?

Com o bind configurado em 0.0.0.0:5432->5432/tcp, qualquer processo na máquina host, ou em rede local, dependendo do firewall, conseguia se conectar diretamente ao banco de dados dos contêineres da action. Como o banco deve ser acessível apenas internamente pelos serviços do Compose, a porta não precisa ser publicada no host. A correção remove o bind externo, deixando o PostgreSQL acessível somente dentro da rede interna do Docker, garantindo o isolamento esperado em ambientes de CI/CD.

---

### Critérios de aceitação

1. [x] O contêiner msgram-postgres não expõe a porta 5432 no host (docker ps não exibe 0.0.0.0:5432->5432/tcp)?
2.  [x] Os serviços internos do Compose (msgram-service, msgram-action) continuam conseguindo se conectar ao banco normalmente?
3. [x]  Conexões externas ao host na porta 5432 são recusadas após a correção?
4. [x]  Nenhuma variável de ambiente ou configuração de conexão dos outros serviços precisou ser alterada?
5.  [x] O ambiente sobe corretamente com docker compose up sem erros relacionados ao banco?


---

### Imagens

Antes:
<img width="1268" height="162" alt="image" src="https://github.com/user-attachments/assets/13aa9677-0aa5-452f-ae29-2b190a195389" />

Depois:
<img width="1253" height="162" alt="image" src="https://github.com/user-attachments/assets/393aa25d-4d91-4133-b40c-bd712580d88e" />


