### PR TITLE
fix: corrige BUG013 e BUG012

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: '2024.1 Action MeasureSoftGram'
+name: '2026.1 Action MeasureSoftGram'
 description: 'Use the product MeasureSoftGram and show the results in the pull requests.'
 inputs:
   host:

--- a/src/service/request-service.ts
+++ b/src/service/request-service.ts
@@ -126,9 +126,8 @@ export class RequestService {
       method,
       url,
       data,
+      timeout: 50000,
     };
-
-    axios.defaults.timeout = 50000; // await for heroku to wake up
 
     let response: AxiosResponse | null = null;
     try {


### PR DESCRIPTION
## Resumo

- **BUG013**: Atualiza `name` em `action.yml` de `'2024.1 Action MeasureSoftGram'` para `'2026.1 Action MeasureSoftGram'`
- **BUG012**: Move `axios.defaults.timeout` (global) para o campo `timeout` dentro do `AxiosRequestConfig` da requisição, isolando o timeout do cliente MSG Service e evitando efeito colateral no cliente SonarCloud

## Issues fechadas

Closes #13
Closes #12