### PR TITLE
fix: substitui token real por placeholder no .action.env de exemplo

### DIFF
--- a/env-vars-example/.action.env
+++ b/env-vars-example/.action.env
@@ -1,8 +1,8 @@
-GITHUB_TOKEN=TOKEN
-SONAR_TOKEN=fga-eps-mds_MeasureSoftGram-Action
-MSGRAM_TOKEN=008eb933b3f464e8f7c28dd3e5b01516398a0f3b
+GITHUB_TOKEN=your-github-token
+SONAR_TOKEN=your-sonar-token
+MSGRAM_TOKEN=your-msgram-service-token
 MSGRAM_SERVICE_HOST=http://localhost:8080
 
 # Caso queira testar o envio para o dockerhub:
-DOCKERHUB_USERNAME=EXAMPLE
-DOCKERHUB_TOKEN=EXAMPLE
+DOCKERHUB_USERNAME=your-dockerhub-username
+DOCKERHUB_TOKEN=your-dockerhub-token


### PR DESCRIPTION
## O que

Substitui os valores do arquivo de exemplo `env-vars-example/.action.env` por placeholders no padrao `your-xxx`.

## Por que

O arquivo continha um `MSGRAM_TOKEN` real (40 chars) versionado desde abril de 2026, e o campo `SONAR_TOKEN` trazia um valor de project key (`fga-eps-mds_MeasureSoftGram-Action`) em vez de placeholder. Arquivos de exemplo nunca devem conter segredos nem valores que pareçam configuracao real, para nao vazar credencial e nao confundir quem copia o exemplo.

## Acao complementar necessaria (fora deste PR)

Como o token real esteve versionado por ~3 meses, ele continua no historico do git mesmo apos esta troca. A protecao efetiva e **rotacionar o `MSGRAM_TOKEN`** (invalidar o token exposto e gerar um novo). Reescrever o historico nao e recomendado num repositorio compartilhado.

O `SONAR_TOKEN` antigo era um project key publico, nao um segredo: nao precisa rotacionar.

Closes #18
