### PR TITLE
fix(ci): migra runtime da Action de node16 para node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,5 +33,5 @@ inputs:
     required: true
     description: "Flag to determine if Github metrics should be collected"
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Migra o runtime da Action de `node16` (deprecado pelo GitHub Actions, sera removido dos runners) para `node20`, compativel com o `dist` ja compilado e alinhado com `@types/node 20` e os workflows em node 18+.

Closes #19