### PR TITLE
chore(dx): script test roda uma vez + make test/lint diretos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+test:
+	yarn test
+
+lint:
+	yarn lint
+
 update-dist:
 	npm install
 	npm run build

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "ncc build src/index.ts --source-map --license licenses.txt --out dist",
     "lint": "eslint src/ --ext .ts",
-    "test": "jest src/ --watch --coverage --verbose --onlyChanged --passWithNoTests",
+    "test": "jest src/ --coverage --passWithNoTests",
+    "test:watch": "jest src/ --watch --coverage --onlyChanged --passWithNoTests",
     "ci:test": "jest --passWithNoTests"
   },
   "repository": {


### PR DESCRIPTION
O script `test` rodava em `--watch --onlyChanged`, travando CI e onboarding. Agora `test` roda a suite uma vez com cobertura; o watch fica em `test:watch`. Adiciona `make test` e `make lint` que rodam direto (sem docker/act).

Closes #20