### PR TITLE
chore(dx): padroniza gerenciador em yarn + documenta setup local

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,8 +19,8 @@ jobs:
           node-version: 18.x
       
       - name: Instalar dependências
-        run: npm install
+        run: yarn install --frozen-lockfile
 
       - name: Rodar ESLint + Prettier
-        run: npm run lint
+        run: yarn lint
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 update-dist:
-	npm install
-	npm run build
+	yarn install --frozen-lockfile
+	yarn build
 
 build: update-dist
 	docker compose up --build

--- a/README.md
+++ b/README.md
@@ -72,3 +72,20 @@ Lembre-se que é necessário que você disponha do seu token do GitHub para exec
 Os resultados são adicionados ao website do MeasureSoftwareGram e exibidos nesse gráfico:
 
 ![Resultado Web](./assets/images/resultado_msgram.png)
+## Desenvolvimento local
+
+O gerenciador de pacotes padrão deste repositório é o **Yarn** (o `yarn.lock` é o
+lockfile versionado). Use Yarn em todos os passos para evitar divergência de
+dependências.
+
+```bash
+yarn install --frozen-lockfile
+yarn lint            # ESLint + Prettier
+yarn test            # roda a suíte uma vez, com cobertura
+yarn build           # compila src/ para dist/ com o ncc
+```
+
+> **Importante:** a Action é executada a partir do código já compilado em
+> `dist/index.js`, então o `dist/` **precisa ser versionado**. Sempre que alterar
+> algo em `src/`, rode `yarn build` e faça commit do `dist/` atualizado junto com
+> a mudança. O alvo `make update-dist` faz `yarn install` + `yarn build` de uma vez.


### PR DESCRIPTION
O repo versiona `yarn.lock` e o CI de teste usa yarn, mas o Makefile (`update-dist`) e o `linter.yml` usavam `npm install`. Padroniza em `yarn install --frozen-lockfile` + yarn e adiciona a secao 'Desenvolvimento local' no README (fluxo install/lint/test/build + regra de versionar o `dist/`).

Closes #21